### PR TITLE
feat: Add on-page console log display

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,5 +65,10 @@
          Using @0.12.10 as an example, check the ffmpeg.wasm docs for latest recommended versions and practices.
          The core is often loaded dynamically by ffmpeg.min.js, but explicit core loading might be needed for some setups. -->
     <script src="script.js"></script>
+
+    <div id="onPageConsoleContainer">
+        <h2>Console Logs</h2>
+        <div id="onPageConsole"></div>
+    </div>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,82 @@
 console.log("script.js loaded");
 
+// --- On-page console logger ---
+const onPageConsole = document.getElementById('onPageConsole');
+
+const originalConsole = {
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    debug: console.debug.bind(console)
+};
+
+function createLogMessageElement(message, level) {
+    const logEntry = document.createElement('div');
+    logEntry.classList.add('log-entry', `log-${level}`);
+
+    let displayMessage = '';
+    if (typeof message === 'object') {
+        try {
+            displayMessage = JSON.stringify(message, null, 2);
+            logEntry.innerHTML = `<pre>${displayMessage}</pre>`; // Use pre for formatted JSON
+        } catch (e) {
+            displayMessage = '[Unserializable Object]';
+            logEntry.textContent = displayMessage;
+        }
+    } else {
+        displayMessage = String(message);
+        logEntry.textContent = displayMessage;
+    }
+
+    if (onPageConsole) {
+        onPageConsole.appendChild(logEntry);
+        onPageConsole.scrollTop = onPageConsole.scrollHeight; // Auto-scroll to bottom
+    }
+    return displayMessage; // Return string representation for original console
+}
+
+console.log = function(...args) {
+    const messageStr = args.map(arg => createLogMessageElement(arg, 'log')).join(' ');
+    originalConsole.log(...args); // Call original console.log with all arguments
+};
+
+console.warn = function(...args) {
+    const messageStr = args.map(arg => createLogMessageElement(arg, 'warn')).join(' ');
+    originalConsole.warn(...args);
+};
+
+console.error = function(...args) {
+    const messageStr = args.map(arg => createLogMessageElement(arg, 'error')).join(' ');
+    originalConsole.error(...args);
+};
+
+console.info = function(...args) {
+    const messageStr = args.map(arg => createLogMessageElement(arg, 'info')).join(' ');
+    originalConsole.info(...args);
+};
+
+console.debug = function(...args) {
+    // Debug messages might be too verbose for on-page, but we'll include them
+    const messageStr = args.map(arg => createLogMessageElement(arg, 'debug')).join(' ');
+    originalConsole.debug(...args);
+};
+
+// Catch global errors and log them too
+window.onerror = function(message, source, lineno, colno, error) {
+    console.error("Uncaught Error:", { message, source, lineno, colno, errorObj: error ? error.stack || error : 'N/A' });
+    return false; // Let default handler run as well
+};
+
+window.onunhandledrejection = function(event) {
+    console.error("Unhandled Promise Rejection:", event.reason ? event.reason.stack || event.reason : 'N/A');
+};
+// --- End On-page console logger ---
+
 document.addEventListener('DOMContentLoaded', () => {
+    // Ensure onPageConsole is re-fetched after DOM is loaded, if it wasn't available globally at script start
+    // const onPageConsole = document.getElementById('onPageConsole'); // Already defined globally
+
     const imageUpload = document.getElementById('imageUpload');
     const textInput = document.getElementById('textInput');
     const durationInput = document.getElementById('durationInput');

--- a/style.css
+++ b/style.css
@@ -107,3 +107,74 @@ button:hover {
     margin-top: 10px;
     border: 1px solid #ccc;
 }
+
+/* On-Page Console Styles */
+#onPageConsoleContainer {
+    margin-top: 30px;
+    padding: 15px;
+    background-color: #2c3e50; /* Dark background for console */
+    color: #ecf0f1; /* Light text for console */
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}
+
+#onPageConsoleContainer h2 {
+    color: #ecf0f1; /* Light heading text */
+    margin-top: 0;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #34495e;
+    padding-bottom: 10px;
+}
+
+#onPageConsole {
+    background-color: #34495e; /* Slightly lighter dark for the log area */
+    color: #ecf0f1;
+    min-height: 100px;
+    max-height: 400px; /* Limit height and make scrollable */
+    overflow-y: auto;   /* Enable vertical scrolling */
+    padding: 10px;
+    border-radius: 4px;
+    font-family: 'Courier New', Courier, monospace; /* Monospaced font for logs */
+    font-size: 0.9em;
+    line-height: 1.4;
+    white-space: pre-wrap; /* Wrap long lines, preserve whitespace */
+}
+
+.log-entry {
+    padding: 4px 6px;
+    border-bottom: 1px solid #2c3e50; /* Separator lines */
+    margin-bottom: 2px;
+}
+
+.log-entry:last-child {
+    border-bottom: none;
+}
+
+.log-log {
+    color: #ecf0f1; /* Default log text color (already light) */
+}
+
+.log-info {
+    color: #3498db; /* Blue for info */
+}
+
+.log-warn {
+    color: #f39c12; /* Orange for warnings */
+    font-weight: bold;
+}
+
+.log-error {
+    color: #e74c3c; /* Red for errors */
+    font-weight: bold;
+}
+
+.log-debug {
+    color: #95a5a6; /* Grey for debug */
+    font-style: italic;
+}
+
+.log-entry pre {
+    margin: 0;
+    white-space: pre-wrap;       /* Since CSS 2.1 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}


### PR DESCRIPTION
- Added a dedicated section to index.html to display console logs.
- Overrode console.log, .warn, .error, .info, .debug in script.js to pipe messages to this HTML section.
- Preserved original console behavior.
- Added styling for the on-page console and different log levels in style.css.
- Included global error handlers (window.onerror, window.onunhandledrejection) to capture and display uncaught errors and unhandled promise rejections.