### PR TITLE
Fix: Update FFmpeg URL to resolve MIME type and ReferenceError

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
     <a id="downloadLink" style="display:none;" download="output.mp4">Download Video</a>
     <canvas id="previewCanvas" style="display:none;"></canvas> <!-- Hidden canvas for processing -->
 
-    <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.10/dist/ffmpeg.min.js"></script>
+    <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.15/dist/umd/ffmpeg.js"></script>
     <!-- Make sure to use a version of ffmpeg.js that is compatible with the version of ffmpeg-core you intend to use.
-         Using @0.12.10 as an example, check the ffmpeg.wasm docs for latest recommended versions and practices.
+         Using @0.12.15 as an example, check the ffmpeg.wasm docs for latest recommended versions and practices.
          The core is often loaded dynamically by ffmpeg.min.js, but explicit core loading might be needed for some setups. -->
     <script src="script.js"></script>
 


### PR DESCRIPTION
Changed the FFmpeg script URL in index.html to point to a version and path on unpkg.com that serves the file with the correct 'text/javascript' MIME type.

Old URL: https://unpkg.com/@ffmpeg/ffmpeg@0.12.10/dist/ffmpeg.min.js
New URL: https://unpkg.com/@ffmpeg/ffmpeg@0.12.15/dist/umd/ffmpeg.js

This resolves the browser blocking the script and the subsequent 'ReferenceError: FFmpeg is not defined' when trying to initialize FFmpeg.