### PR TITLE
Fix: Switch to jsDelivr CDN for FFmpeg library

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
     <a id="downloadLink" style="display:none;" download="output.mp4">Download Video</a>
     <canvas id="previewCanvas" style="display:none;"></canvas> <!-- Hidden canvas for processing -->
 
-    <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.15/dist/umd/ffmpeg.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.15/dist/umd/ffmpeg.js"></script>
     <!-- Make sure to use a version of ffmpeg.js that is compatible with the version of ffmpeg-core you intend to use.
-         Using @0.12.15 as an example, check the ffmpeg.wasm docs for latest recommended versions and practices.
+         Using @0.12.15 from jsDelivr as an example, check the ffmpeg.wasm docs for latest recommended versions and practices.
          The core is often loaded dynamically by ffmpeg.min.js, but explicit core loading might be needed for some setups. -->
     <script src="script.js"></script>
 


### PR DESCRIPTION
Updated the FFmpeg script URL in index.html to use jsDelivr CDN instead of unpkg.com. New URL: https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.15/dist/umd/ffmpeg.js

This change ensures the FFmpeg library is loaded with the correct MIME type, preventing browser errors and allowing the application to initialize FFmpeg correctly.