### PR TITLE
Fix: Correct FFmpeg instantiation to use FFmpegWASM.FFmpeg

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,8 +275,8 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log("[Diag][loadFFmpeg] FFmpeg not loaded yet. Proceeding with load sequence.");
 
         try {
-            console.log("[Diag][loadFFmpeg] Instantiating FFmpeg.FFmpeg()...");
-            ffmpeg = new FFmpeg.FFmpeg();
+            console.log("[Diag][loadFFmpeg] Instantiating FFmpegWASM.FFmpeg()...");
+            ffmpeg = new FFmpegWASM.FFmpeg();
             console.log("[Diag][loadFFmpeg] FFmpeg instance created.");
 
             ffmpeg.on('log', ({ type, message }) => {


### PR DESCRIPTION
The FFmpeg UMD library (v0.12.15) loaded from CDN (jsDelivr or unpkg) exposes its main class under the global `FFmpegWASM` object. Updated script.js to call `new FFmpegWASM.FFmpeg()` instead of `new FFmpeg.FFmpeg()` to correctly instantiate the FFmpeg object.

This resolves the "ReferenceError: FFmpeg is not defined" and allows the application to initialize FFmpeg.