### PR TITLE
Fix: Resolve FFmpeg loading CORS issue using toBlobURL

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
     <canvas id="previewCanvas" style="display:none;"></canvas> <!-- Hidden canvas for processing -->
 
     <script src="https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.15/dist/umd/ffmpeg.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@ffmpeg/util@0.12.2/dist/umd/index.js"></script>
     <!-- Make sure to use a version of ffmpeg.js that is compatible with the version of ffmpeg-core you intend to use.
          Using @0.12.15 from jsDelivr as an example, check the ffmpeg.wasm docs for latest recommended versions and practices.
          The core is often loaded dynamically by ffmpeg.min.js, but explicit core loading might be needed for some setups. -->

--- a/script.js
+++ b/script.js
@@ -295,8 +295,16 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             console.log("[Diag][loadFFmpeg] Event listeners for log and progress attached.");
 
-            console.log("[Diag][loadFFmpeg] Calling ffmpeg.load()...");
-            await ffmpeg.load();
+            const coreVersion = "0.12.6"; // As per documentation for ffmpeg.wasm v0.12.x
+            const baseURL = `https://cdn.jsdelivr.net/npm/@ffmpeg/core@${coreVersion}/dist/umd`;
+            console.log(`[Diag][loadFFmpeg] Base URL for core assets: ${baseURL}`);
+
+            console.log("[Diag][loadFFmpeg] Calling ffmpeg.load() with explicit core/wasm URLs using toBlobURL...");
+            await ffmpeg.load({
+                coreURL: await FFmpegUtil.toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
+                wasmURL: await FFmpegUtil.toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm')
+                // Not including workerURL for now to stick to single-thread, to avoid SharedArrayBuffer issues on GitHub Pages
+            });
             console.log("[Diag][loadFFmpeg] ffmpeg.load() completed.");
 
             ffmpegLoaded = true;


### PR DESCRIPTION
Implemented the recommended approach from FFmpeg.wasm documentation to resolve cross-origin loading errors for core components (ffmpeg-core.js and ffmpeg-core.wasm) when loaded from a CDN.

Changes:
1. Added `@ffmpeg/util` library to index.html to provide `FFmpegUtil.toBlobURL`.
2. Modified `script.js` to explicitly specify `coreURL` and `wasmURL` in the `ffmpeg.load()` options.
3. These URLs point to `@ffmpeg/core@0.12.6` assets on jsDelivr and are wrapped with `FFmpegUtil.toBlobURL`.

This technique creates blob URLs for the core components, making them appear as same-origin resources to the browser, thus bypassing CORS restrictions that were preventing FFmpeg from initializing correctly on GitHub Pages.