### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Function to update status messages
     function updateStatus(message) {
-        statusMessages.innerHTML = `<p>${message}</p>`;
+        statusMessages.textContent = message;
         console.log(message);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/XiaoRaph/PytoMov/security/code-scanning/1](https://github.com/XiaoRaph/PytoMov/security/code-scanning/1)

To fix the issue, the `message` variable should be safely escaped before being inserted into the DOM using `innerHTML`. This can be achieved by using `textContent` instead of `innerHTML`, which ensures that the content is treated as plain text rather than HTML. Alternatively, a library like `DOMPurify` can be used to sanitize the input if HTML rendering is required.

**Best fix:**
- Replace `statusMessages.innerHTML = `<p>${message}</p>`;` with `statusMessages.textContent = message;`. This ensures that the `message` is treated as plain text, preventing any potential XSS attacks.

**Changes needed:**
- Modify line 135 in `script.js` to use `textContent` instead of `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
