### PR TITLE
Fix: Ensure Whammy.js is loaded before script.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
     <a id="downloadLink" style="display:none;" download="output.webm">Download Video (WebM)</a>
     <canvas id="previewCanvas" style="display:none;"></canvas> <!-- Hidden canvas for processing -->
 
+    <script src="lib/whammy.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Added the script tag for lib/whammy.js in index.html to ensure it is loaded before script.js, which depends on it. This resolves the ReferenceError for Whammy.