### PR TITLE
Fix: Correctly handle Whammy.js compile output for Blob creation

### DIFF
--- a/script.js
+++ b/script.js
@@ -343,12 +343,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
             console.log("[Diag][generateVideoCanvas] Compiling WebM video...");
             updateStatus("Compiling WebM video... This might take a moment.");
-            // Whammy's compile is synchronous for the array output, then we make it a blob.
-            const output = video.compile();
-            const videoBlob = new Blob(output, { type: 'video/webm' });
+            // Whammy's compile() method returns a Blob directly when called without arguments (outputAsArray is false).
+            const videoBlob = video.compile();
             const videoUrl = URL.createObjectURL(videoBlob);
 
-            console.log("[Diag][generateVideoCanvas] WebM video compiled. Blob URL created.");
+            console.log("[Diag][generateVideoCanvas] WebM video Blob received from compile(). Blob URL created.");
 
             downloadLink.href = videoUrl;
             downloadLink.download = `video_output_${Date.now()}.webm`;


### PR DESCRIPTION
Whammy.js's compile() method returns a Blob directly when its `outputAsArray` argument is false (which is the default when called with no arguments). The script was attempting to create a new Blob from this already-Blob object, causing a TypeError.

This commit changes script.js to use the Blob returned by compile() directly.