### PR TITLE
Feature: Allow initial video segment to be unfiltered

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ PytoMov is a simple web-based tool that allows you to create a video file from a
     *   Optionally add a background color to your text for better visibility.
 *   **Video Settings:**
     *   Set video duration and Frames Per Second (FPS).
+    *   Specify a number of initial frames to remain unfiltered before an image filter applies.
 *   **Client-Side Processing:** Video generation happens directly in your web browser.
 *   **Download Video:** Get your output as a `.webm` video file.
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
     </div>
 
     <div>
+        <label for="originalFramesInput">Original Frames at Start:</label>
+        <input type="number" id="originalFramesInput" value="0" min="0">
+    </div>
+
+    <div>
         <label for="imageFilterInput">Image Filter:</label>
         <select id="imageFilterInput">
             <option value="none" selected>None</option>


### PR DESCRIPTION
- Added an input field in index.html for 'Original Frames at Start', allowing users to specify how many initial frames of the video should use the original image before any selected filter is applied.
- Modified script.js:
  - Updated generateVideoWithCanvas() to read this new input.
  - During video frame generation, if the current frame index is within the specified 'original frames' count, the 'none' filter is forced. Otherwise, the user-selected filter is applied.
  - applyImageFilter() and drawTextOnCanvas() were updated to support overriding the filter choice for specific frame rendering needs during video generation, while maintaining normal behavior for live preview.
- Updated README.md to include this new video setting feature.