### PR TITLE
Fix: Clarify UI label for initial unfiltered frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     </div>
 
     <div>
-        <label for="originalFramesInput">Original Frames at Start:</label>
+        <label for="originalFramesInput">Initial Unfiltered Frames:</label>
         <input type="number" id="originalFramesInput" value="0" min="0">
     </div>
 


### PR DESCRIPTION
Changed the label in index.html from 'Original Frames at Start:' to 'Initial Unfiltered Frames:' for better clarity. The functionality ensures these initial frames show the original, unfiltered image before any selected filter is applied to subsequent frames.