### PR TITLE
Feature: Add side-by-side original and filtered image previews (close…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ PytoMov is a simple web-based tool that allows you to create a video file from a
 ## Features
 
 *   **Upload Your Image:** Start with any image from your computer.
+*   **Dual Preview:** See your original image alongside a live preview of the final output with filters and text.
 *   **Apply Image Filters:** Currently includes "Invert Colors (Negative)". More to come!
 *   **Overlay Custom Text:** Add your desired message to the image.
 *   **Customize Text Appearance:**

--- a/index.html
+++ b/index.html
@@ -84,8 +84,19 @@
         <p>Status: Idle</p>
     </div>
 
+    <div id="previewArea" style="display: none; margin-top: 20px;">
+        <div class="canvas-container">
+            <h3>Original Image</h3>
+            <canvas id="originalPreviewCanvas"></canvas>
+        </div>
+        <div class="canvas-container">
+            <h3>Live Preview (with Effects & Text)</h3>
+            <canvas id="previewCanvas"></canvas> <!-- Existing canvas -->
+        </div>
+    </div>
+
     <a id="downloadLink" style="display:none;" download="output.webm">Download Video (WebM)</a>
-    <canvas id="previewCanvas" style="display:none;"></canvas> <!-- Hidden canvas for processing -->
+    <!-- Hidden canvas for processing was previewCanvas, it's now visible in previewArea -->
 
     <script src="lib/whammy.js"></script>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -96,7 +96,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const clearBgColorBtn = document.getElementById('clearBgColorBtn');
     const enableBgColorCheckbox = document.getElementById('enableBgColor');
     const textPositionInput = document.getElementById('textPositionInput');
-    const imageFilterInput = document.getElementById('imageFilterInput'); // New image filter dropdown
+    const imageFilterInput = document.getElementById('imageFilterInput');
+
+    const previewArea = document.getElementById('previewArea');
+    const originalPreviewCanvas = document.getElementById('originalPreviewCanvas');
+    const originalCtx = originalPreviewCanvas.getContext('2d');
 
     let loadedImage = null; // Holds the currently loaded image object
 
@@ -110,22 +114,28 @@ document.addEventListener('DOMContentLoaded', () => {
                     loadedImage = new Image();
                     // Event handler for when the image data has been loaded
                     loadedImage.onload = () => {
-                        // Set canvas dimensions to match the loaded image
+                        // Set dimensions for both canvases
+                        originalPreviewCanvas.width = loadedImage.width;
+                        originalPreviewCanvas.height = loadedImage.height;
                         previewCanvas.width = loadedImage.width;
                         previewCanvas.height = loadedImage.height;
-                        // Draw the image onto the canvas
-                        ctx.clearRect(0, 0, previewCanvas.width, previewCanvas.height); // Clear previous content
-                        ctx.drawImage(loadedImage, 0, 0);
-                        previewCanvas.style.display = 'block'; // Make canvas visible
+
+                        // Draw the original image onto the originalPreviewCanvas
+                        originalCtx.clearRect(0, 0, originalPreviewCanvas.width, originalPreviewCanvas.height);
+                        originalCtx.drawImage(loadedImage, 0, 0);
+
+                        // Show the preview area
+                        previewArea.style.display = 'flex'; // Assuming flex is used for layout
+
                         updateStatus(`Image "${file.name}" loaded.`);
-                        // Update the canvas with text overlay now that the image is loaded
+                        // Update the main preview canvas (with filters/text)
                         drawTextOnCanvas();
                     };
                     // Event handler for errors during image loading
                     loadedImage.onerror = () => {
                         updateStatus(`Error loading image: ${file.name}`);
                         loadedImage = null;
-                        previewCanvas.style.display = 'none';
+                        previewArea.style.display = 'none'; // Hide both canvases
                     };
                     loadedImage.src = e.target.result; // Start loading the image data
                 };
@@ -133,7 +143,9 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 // No file selected or selection cleared
                 loadedImage = null;
-                previewCanvas.style.display = 'none';
+                previewArea.style.display = 'none'; // Hide both canvases
+                originalCtx.clearRect(0, 0, originalPreviewCanvas.width, originalPreviewCanvas.height);
+                ctx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
                 updateStatus("Image selection cleared.");
             }
         });

--- a/style.css
+++ b/style.css
@@ -100,13 +100,44 @@ button:hover {
     background-color: #27ae60;
 }
 
-/* Hidden by default, shown via JS if needed for preview */
-#previewCanvas {
-    display: block; /* Changed from none to block for layout testing, JS will control final visibility */
-    max-width: 100%;
-    margin-top: 10px;
-    border: 1px solid #ccc;
+/* Styles for the dual canvas preview area */
+#previewArea {
+    display: flex; /* Uses flexbox for layout */
+    flex-wrap: wrap; /* Allow wrapping on smaller screens */
+    justify-content: space-around; /* Distribute space */
+    align-items: flex-start; /* Align items to the top */
+    padding: 10px;
+    background-color: #e9e9e9; /* Slightly different background for the area */
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+
+.canvas-container {
+    flex: 1; /* Allow containers to grow */
+    min-width: 300px; /* Minimum width before wrapping */
+    margin: 10px;
+    padding: 15px;
+    background-color: #fff;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    text-align: center; /* Center the heading */
+}
+
+.canvas-container h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    color: #333;
+}
+
+#originalPreviewCanvas,
+#previewCanvas {
+    display: block;
+    max-width: 100%; /* Ensure canvas is responsive within its container */
+    margin: 0 auto 10px auto; /* Center canvas and add some bottom margin */
+    border: 1px solid #ccc;
+    background-color: #fff; /* Explicit white background for canvases */
+}
+
 
 /* On-Page Console Styles */
 #onPageConsoleContainer {


### PR DESCRIPTION
…s #20)

- Implemented a dual canvas display to show the original uploaded image alongside the live preview that includes filters and text.
- Updated index.html to include a new 'originalPreviewCanvas' within a shared 'previewArea' container, along with labels for clarity.
- Added CSS in style.css to manage the layout of the two preview canvases (side-by-side with flexbox, responsive).
- Modified script.js to:
  - Get references to the new canvas and its context.
  - Draw the original image to 'originalPreviewCanvas' upon load.
  - Control the visibility of the 'previewArea' (showing both canvases when an image is loaded, hiding when cleared).
- Updated README.md to list the dual preview feature.