### PR TITLE
Refactor: Make video generation asynchronous and add quality option

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,17 @@
         <input type="number" id="fpsInput" value="24" min="1">
     </div>
 
+    <!-- New Quality Input -->
+    <div>
+        <label for="qualityInput">Video Quality (for WebP frames):</label>
+        <select id="qualityInput">
+            <option value="0.92">High (0.92)</option>
+            <option value="0.8" selected>Medium (0.8)</option>
+            <option value="0.5">Low (0.5)</option>
+            <option value="0.3">Very Low (0.3)</option>
+        </select>
+    </div>
+
     <div>
         <label for="originalFramesInput">Initial Unfiltered Frames:</label>
         <input type="number" id="originalFramesInput" value="0" min="0">


### PR DESCRIPTION
- Modified the video generation loop in `script.js` to be asynchronous using `setTimeout`, preventing UI freezes during frame processing.
- Added a quality selection dropdown in `index.html` (High, Medium, Low, Very Low).
- Passed the selected quality setting to `Whammy.Video` to control the quality of WebP frames generated by `toDataURL`.
- This should improve performance and stability, especially on resource-constrained devices like Android, by reducing processing load and memory for lower quality settings.