### PR TITLE
feat: Add timed Sepia effect and staged video rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,13 @@
         <select id="imageFilterInput">
             <option value="none" selected>None</option>
             <option value="invert">Invert Colors (Negative)</option>
+            <option value="sepia">Sepia Tone</option>
         </select>
+    </div>
+
+    <div>
+        <label for="effectActiveDurationInput">Selected Effect Active Duration (seconds):</label>
+        <input type="number" id="effectActiveDurationInput" value="5" min="0">
     </div>
 
     <div>


### PR DESCRIPTION
- Adds a Sepia image filter option.
- Introduces 'Selected Effect Active Duration' input to control the duration of the chosen filter.
- Modifies video generation to support three stages:
  1. Initial unfiltered segment.
  2. Selected filter active segment (e.g., Sepia).
  3. Final unfiltered segment.
- Updates HTML to include new UI elements and script.js for the new logic.