### PR TITLE
Fix: Remove reference to non-existent originalFramesInput

### DIFF
--- a/script.js
+++ b/script.js
@@ -717,7 +717,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         console.log(`[Diag][MediaRecorder] Using MIME type: ${supportedMimeType}`);
-        console.log(`[Diag][MediaRecorder] Inputs: durationSec=${durationSec}, fpsVal=${fpsVal}, numOriginalFrames=${parseInt(originalFramesInput.value, 10) || 0}`);
+        console.log(`[Diag][MediaRecorder] Inputs: durationSec=${durationSec}, fpsVal=${fpsVal}`);
 
         updateStatus("Starting video generation with MediaRecorder... This may take some time.");
         generateBtn.disabled = true;


### PR DESCRIPTION
The originalFramesInput element was removed from the HTML, but a reference to it remained in the JavaScript code, causing a TypeError.

This commit removes the unnecessary console.log line that referenced originalFramesInput.value, as the effect sequencing feature now handles the functionality previously provided by this input.