### PR TITLE
Fix: Re-add timeslice to MediaRecorder.start()

### DIFF
--- a/script.js
+++ b/script.js
@@ -564,8 +564,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
 
-            mediaRecorder.start(); // No timeslice, no setTimeout wrapper, as per PR #27
-            console.log("[Diag][MediaRecorder] MediaRecorder started."); // Log from PR #27
+            mediaRecorder.start(100); // Re-add timeslice to encourage ondataavailable
+            console.log("[Diag][MediaRecorder] MediaRecorder started (with 100ms timeslice).");
             updateStatus("Recording in progress...");
 
             currentFrame = 0; // Ensure currentFrame is 0 before starting render loop


### PR DESCRIPTION
Attempts to ensure MediaRecorder events fire reliably. This commit re-introduces a 100ms timeslice to `mediaRecorder.start(100)`.

This is intended to force the `ondataavailable` event to fire periodically, which is crucial for collecting video data and for the `onstop` event to function correctly in processing the final video.

This change is based on the observation that `ondataavailable` and `onstop` were not firing even when `MediaRecorder.start()` was called and the rendering loop was active.