### PR TITLE
Fix: Call mediaRecorder.requestData() periodically

### DIFF
--- a/script.js
+++ b/script.js
@@ -462,6 +462,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (currentFrame % fpsVal === 0) { // Log status once per second (approx)
                         updateStatus(`Rendering frame ${currentFrame + 1}/${totalFrames} (Filter: ${filterForThisFrame}). Recorder state: ${mediaRecorder.state}`);
                         console.log(`[Diag][MediaRecorder] Render loop: Frame ${currentFrame + 1}/${totalFrames}. Filter: ${filterForThisFrame}. Recorder state: ${mediaRecorder.state}`);
+                        if (mediaRecorder && mediaRecorder.state === "recording") {
+                            console.log(`[Diag][MediaRecorder] Requesting data explicitly for frame ${currentFrame + 1}`);
+                            mediaRecorder.requestData();
+                        }
                     }
                     currentFrame++;
                     renderLoopId = requestAnimationFrame(renderFrame);


### PR DESCRIPTION
In an attempt to force the `ondataavailable` event to fire, this commit modifies the `renderFrame` loop to call `mediaRecorder.requestData()` approximately once per second if the recorder is in the 'recording' state.

This is a diagnostic step to see if explicitly requesting data can overcome issues where `ondataavailable` is not firing automatically despite the recorder state being 'recording' and a timeslice being set.