### PR TITLE
Fix: Remove explicit requestData call in MediaRecorder

### DIFF
--- a/script.js
+++ b/script.js
@@ -462,10 +462,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (currentFrame % fpsVal === 0) { // Log status once per second (approx)
                         updateStatus(`Rendering frame ${currentFrame + 1}/${totalFrames} (Filter: ${filterForThisFrame}). Recorder state: ${mediaRecorder.state}`);
                         console.log(`[Diag][MediaRecorder] Render loop: Frame ${currentFrame + 1}/${totalFrames}. Filter: ${filterForThisFrame}. Recorder state: ${mediaRecorder.state}`);
-                        if (mediaRecorder && mediaRecorder.state === "recording") {
-                            console.log(`[Diag][MediaRecorder] Requesting data explicitly for frame ${currentFrame + 1}`);
-                            mediaRecorder.requestData();
-                        }
+                        // Removed explicit mediaRecorder.requestData(); call
+                        // The timeslice parameter in mediaRecorder.start() should handle dataavailable events.
                     }
                     currentFrame++;
                     renderLoopId = requestAnimationFrame(renderFrame);


### PR DESCRIPTION
The explicit call to mediaRecorder.requestData() within the render loop was likely interfering with the timeslice-based data gathering initiated by mediaRecorder.start(100). This interference is suspected to be the cause of ondataavailable events firing with 0-sized chunks.

By removing this explicit call, the MediaRecorder should now rely solely on the timeslice mechanism to trigger dataavailable events, which is expected to resolve the issue and produce valid video data.