### PR TITLE
feat: Add MP3 audio upload and integration into video generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,11 @@
     </div>
 
     <div>
+        <label for="audioUpload">Upload MP3 Audio (optional):</label>
+        <input type="file" id="audioUpload" accept="audio/mpeg">
+    </div>
+
+    <div>
         <label for="textInput">Overlay Text:</label>
         <input type="text" id="textInput" value="Hello World">
     </div>


### PR DESCRIPTION
- Added a file input in index.html for MP3 audio uploads.
- Implemented JavaScript logic to read the uploaded MP3 file as an ArrayBuffer.
- Modified the `generateVideoWithMediaRecorder` function to:
  - Decode the MP3 data using the Web Audio API.
  - Create an audio track from the decoded MP3.
  - Loop audio if it's shorter than the video duration; otherwise, it's truncated.
  - Merge the audio track with the canvas video track into a single MediaStream.
  - Handle errors during audio decoding gracefully, allowing video generation to proceed without audio.
- Updated status messages and console logs for better feedback and debugging.