### PR TITLE
Fix: Add missing onPageConsole HTML element

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,11 @@
 
     <a id="downloadLink" style="display:none;" download="output.webm">Download Video (WebM)</a>
 
+    <div id="onPageConsoleContainer">
+        <h2>Console Output</h2>
+        <div id="onPageConsole"></div>
+    </div>
+
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Resolves #51.

Added the 'onPageConsoleContainer' and 'onPageConsole' div elements to index.html as suggested in the issue. This enables the on-page console logging feature which was previously non-functional due to the missing element.